### PR TITLE
Update multiclient to handle non unique IDs

### DIFF
--- a/CelesteArchipelago.csproj
+++ b/CelesteArchipelago.csproj
@@ -43,7 +43,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Archipelago.MultiClient.Net" Version="6.3.1">
+        <PackageReference Include="Archipelago.MultiClient.Net" Version="6.3.1" />
         <PackageReference Include="MonoMod.RuntimeDetour" Version="22.01.04.03" PrivateAssets="all" ExcludeAssets="runtime" />
     </ItemGroup>
 

--- a/CelesteArchipelago.csproj
+++ b/CelesteArchipelago.csproj
@@ -43,7 +43,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Archipelago.MultiClient.Net" Version="5.0.6" />
+        <PackageReference Include="Archipelago.MultiClient.Net" Version="6.3.1">
         <PackageReference Include="MonoMod.RuntimeDetour" Version="22.01.04.03" PrivateAssets="all" ExcludeAssets="runtime" />
     </ItemGroup>
 

--- a/Networking/ArchipelagoController.cs
+++ b/Networking/ArchipelagoController.cs
@@ -168,13 +168,13 @@ namespace Celeste.Mod.CelesteArchipelago
             Connection?.Dispose();
         }
 
-        public void ReceiveItemCallback(ReceivedItemsHelper receivedItemsHelper)
+        public void ReceiveItemCallback(IReceivedItemsHelper receivedItemsHelper)
         {
             while(receivedItemsHelper.Any())
             {
                 // Receive latest uncollected item
-                Logger.Log("CelesteArchipelago", $"Received item {receivedItemsHelper.PeekItemName()} with ID {receivedItemsHelper.PeekItem().Item}");
-                var itemID = receivedItemsHelper.PeekItem().Item;
+                Logger.Log("CelesteArchipelago", $"Received item {receivedItemsHelper.PeekItem().ItemName} with ID {receivedItemsHelper.PeekItem().ItemId}");
+                var itemID = receivedItemsHelper.PeekItem().ItemId;
                 ArchipelagoNetworkItem item = new ArchipelagoNetworkItem(itemID);
 
                 // Collect received item via chosen progression system

--- a/Networking/CheckpointState.cs
+++ b/Networking/CheckpointState.cs
@@ -20,7 +20,7 @@ namespace Celeste.Mod.CelesteArchipelago
             }
         }
         private static List<CheckpointItem> Checkpoints;
-        private DataStorageHelper helper;
+        private IDataStorageHelper helper;
 
         private static void InitCheckpoints()
         {
@@ -45,7 +45,7 @@ namespace Celeste.Mod.CelesteArchipelago
             return Checkpoints.FindIndex((x) => x.Area == area && x.Level == level);
         }
 
-        public CheckpointState(ulong current, DataStorageHelper helper)
+        public CheckpointState(ulong current, IDataStorageHelper helper)
         {
             runningTotal = current;
             if(Checkpoints is null)


### PR DESCRIPTION
This fixes a crash that occurs when loading a datapackage that has non-unique item/location IDs in it. (ArchipelagoMW/Archipelago#3394)